### PR TITLE
Added cloud model with wavelenght-independent constant cross-section

### DIFF
--- a/log/pyratlog.txt
+++ b/log/pyratlog.txt
@@ -1340,5 +1340,17 @@ Bumped pyratbay to version 0.0.16.
 Bumped pyrat    to version 1.2.7.
 Bumped lineread to version 6.4.3.
 
+*****  Sat Mar 12 14:22:21 CET 2016  *****
+
+Added cloud model with wavelenght-independent constant cross-section
+between two adjustable pressure levels.  The magnitude of the cross
+section is adjustable as well.  When calculating the extinction
+coefficient, the cross section is multiplied by the H2 number density
+giving the absorption in cm-1.
+Fixed bug with Rayleigh haze model.
+Resolves #34.
+Bumped pyrat to version 1.2.8.
+
 *****
+
 

--- a/pyratbay/VERSION.py
+++ b/pyratbay/VERSION.py
@@ -8,7 +8,7 @@ PBAY_REV  = 16  # Revision
 # Pyrat version:
 PYRAT_VER =  1  # Major version
 PYRAT_MIN =  2  # Minor version
-PYRAT_REV =  7  # Revision
+PYRAT_REV =  8  # Revision
 
 # Lineread version:
 LR_VER    =  6  # Major version


### PR DESCRIPTION
between two adjustable pressure levels.  The magnitude of the cross
section is adjustable as well.  When calculating the extinction
coefficient, the cross section is multiplied by the H2 number density
giving the absorption in cm-1.
Fixed bug with Rayleigh haze model.
Resolves #34.
Bumped pyrat to version 1.2.8.
