### PR TITLE
Fixed bug in extcoeff.c where kmax was not initialized to zero.

### DIFF
--- a/log/pyratlog.txt
+++ b/log/pyratlog.txt
@@ -1670,3 +1670,8 @@ Bumped Pyrat Bay to version 0.0.23.
 
 *****
 
+Fixed bug in extcoeff.c where kmax was not initialized to zero.
+Bumped Pyrat to version 1.2.14.
+
+*****
+

--- a/pyratbay/VERSION.py
+++ b/pyratbay/VERSION.py
@@ -8,7 +8,7 @@ PBAY_REV  = 23  # Revision
 # Pyrat version:
 PYRAT_VER =  1  # Major version
 PYRAT_MIN =  2  # Minor version
-PYRAT_REV = 13  # Revision
+PYRAT_REV = 14  # Revision
 
 # Lineread version:
 LR_VER    =  6  # Major version

--- a/src_c/extcoeff.c
+++ b/src_c/extcoeff.c
@@ -136,15 +136,15 @@ static PyObject *extinction(PyObject *self, PyObject *args){
   alphal = (double *)malloc(niso * sizeof(double));
   alphad = (double *)malloc(niso * sizeof(double));
 
-  /* Array to hold maximum line strength:                                   */
-  kmax = (double *)malloc(next * sizeof(double));
-
   /* Allocate width indices array:                                          */
   idop = (int *)malloc(niso * sizeof(int));
   ilor = (int *)malloc(niso * sizeof(int));
 
   /* Allocate line strength per transition:                                 */
   kprop = (double *)malloc(nlines * sizeof(double));
+  /* Array to hold maximum line strength:                                   */
+  kmax  = (double *)calloc(next,    sizeof(double));
+
 
   ktmp    = (double **)malloc(next *      sizeof(double *));
   ktmp[0] = (double  *)malloc(next*onwn * sizeof(double  ));
@@ -231,7 +231,7 @@ static PyObject *extinction(PyObject *self, PyObject *args){
   //printf("\n");
 
   /* Compute the extinction-coefficient for each species:                   */
-  for(ln=0; ln<nlines; ln++){
+  for (ln=0; ln<nlines; ln++){
     wavn = INDd(lwn, ln);    /* Wavenumber                                  */
     i    = INDi(lID, ln);    /* Isotope index                               */
     if (add)


### PR DESCRIPTION
Bumped Pyrat Bay to version 1.2.14.
