### PR TITLE
JB added option to read the pressure and temperature from a PT file provided

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3590,12 +3590,9 @@ Bumped Pyrat Bay to version 0.0.81.
 Bumped Pyrat to version 1.2.56.
 Bumped lineread to version 6.4.14.
 
-*****
-
 
 *****  Tue 20. Mar 15:52:18 CET 2018  *****
 
-#--- Jasmina
 changed the following file to add option to read
 pressure and temperature from a file:
 pyrat/argum.py
@@ -3614,4 +3611,11 @@ ptfile = _path_
 Bumped Pyrat Bay to version 0.0.82.
 Bumped Pyrat to version 1.2.57.
 
+
+*****  Mi 4. Apr 11:03:13 CEST 2018  *****
+
+Added docstring to atmosphere.read_ptfile().
+Some other code tweaks and clean up.
+
 *****
+

--- a/pyratbay/atmosphere/atmosphere.py
+++ b/pyratbay/atmosphere/atmosphere.py
@@ -27,12 +27,28 @@ import pt as PT
 thisdir = os.path.dirname(os.path.realpath(__file__))
 indir   = thisdir + "/../../inputs/"
 
-# Jasmina ---
+
 def read_ptfile(ptfile):     
     """
-    Extract pressure, temperature, from ptfile.
-    """
+    Extract pressure, temperature, from a file.
 
+    Parameters
+    ----------
+    ptfile: String
+       Input file with pressure (first column), temperature (second
+       column) arrays.
+
+    Return
+    ------
+    pressure: 1D float ndarray
+       Pressure profile in barye.
+    temperature: 1D float ndarray
+       Temperature profile in Kelvin.
+
+    Notes
+    -----
+    This function assumes that the units of the input pressure are bar.
+    """
     # Open ptfile:
     f = open(ptfile, 'r')
     data = []
@@ -49,18 +65,17 @@ def read_ptfile(ptfile):
     ndata = len(data)
 
     # Allocate arrays of pressure and temperature
-    pres = []
-    temp = []
+    press, temp = [], []
 
     # Read lines and store pressure and temperature data
     for i in np.arange(ndata):
-        pres = np.append(pres, data[i][0])
-        temp = np.append(temp, data[i][1])
-    pressure    = pres.astype(float)*pt.u('bar')
+        press = np.append(press, data[i][0])
+        temp  = np.append(temp,  data[i][1])
+    pressure    = press.astype(float) * pt.u('bar')
     temperature = temp.astype(float)
 
     return pressure, temperature
-# Jasmina ---
+
 
 def writeatm(atmfile, pressure, temperature, species, abundances,
              punits, header, radius=None, runits=None):

--- a/pyratbay/pbay/argum.py
+++ b/pyratbay/pbay/argum.py
@@ -110,11 +110,9 @@ def parse(wlog):
 
   # Atmospheric file:
   group = parser.add_argument_group("Atmospheric-file options")
-  # Jasmina ---
   group.add_argument("--ptfile",    dest="ptfile",
-           help="Pres-temp file [default: %(default)s]",
+           help="Pressure-temperature file [default: None]",
            action="store", type=str,       default=None)
-  # Jasmina ---
   group.add_argument("--atmfile",    dest="atmfile",
            help="Atmospheric file [default: %(default)s]",
            action="store", type=str,       default=None)

--- a/pyratbay/pbay/driver.py
+++ b/pyratbay/pbay/driver.py
@@ -80,14 +80,13 @@ def run(argv, main=False):
       args.gplanet = (pc.G * pt.getparam(args.mplanet, "gram") /
                       pt.getparam(args.rplanet, args.radunits)**2)
 
-    # Jasmina ---
     # Compute pressure-temperature profile:
     if args.runmode in ["pt", "atmosphere"] or pt.isfile(args.atmfile) != 1:
       # Check if PT file is provided:
       if args.ptfile is None:
         ar.checkpressure(args, log, wlog)  # Check pressure inputs
         pressure = atm.pressure(args.ptop, args.pbottom, args.nlayers,
-                             args.punits, log)
+                                args.punits, log)
         ar.checktemp(args, log, wlog)      # Check temperature inputs
         temperature = atm.temperature(args.tmodel, pressure,
            args.rstar, args.tstar, args.tint, args.gplanet, args.smaxis,
@@ -95,10 +94,9 @@ def run(argv, main=False):
 
       # If PT file is provided, read it:
       elif os.path.isfile(args.ptfile):
-        pt.msg(4, "\nReading pres-temp file:"
-              "\n  '{:s}'.".format(args.ptfile), log)
+        pt.msg(pyrat.verb-3, "\nReading pressure-temperature file:"
+               " '{:s}'.".format(args.ptfile), log)
         pressure, temperature = atm.read_ptfile(args.ptfile)
-    # Jasmina ---
 
     # Return temperature-pressure if requested:
     if args.runmode == "pt":

--- a/pyratbay/pyrat/argum.py
+++ b/pyratbay/pyrat/argum.py
@@ -71,10 +71,6 @@ def parse(pyrat, log=None):
   parser = argparse.ArgumentParser(parents=[cparser])  #, add_help=False) ??
   # Process pyrat Options:
   group = parser.add_argument_group("Input Files Options")
-  # Jasmina ---
-  pt.addarg("ptfile",     group, str,       None,     
-      "Pressure temperature file [default: %(default)s]")
-  # Jasmina ---
   pt.addarg("atmfile",     group, str,       None,
       "Atmospheric file [default: %(default)s]")
   pt.addarg("linedb",      group, pt.parray, None,
@@ -265,10 +261,7 @@ def parse(pyrat, log=None):
   pyrat.inputs.runmode    = user.runmode
   pyrat.inputs.verb       = user.verb
   pyrat.inputs.nproc      = user.nproc
-  # Input file:
-  # Jasmina ---
-  pyrat.inputs.ptfile     = user.ptfile
-  # Jasmina ---
+  # Input files:
   pyrat.inputs.atmfile    = user.atmfile
   pyrat.inputs.linedb     = user.linedb
   pyrat.inputs.csfile     = user.csfile
@@ -397,15 +390,6 @@ def checkinputs(pyrat):
   if pyrat.runmode not in pc.rmodes:
     pt.error("Invalid runmode ({:s}).  Select from: {}.".
               format(pyrat.runmode, pc.rmodes), pyrat.log)
-
-  # Jasmina ---
-  # Check that input files exist:   
-  if inputs.ptfile is not None:  
-    if not os.path.exists(os.path.realpath(os.path.dirname(inputs.ptfile))):
-      pt.error("Pressure-temperature file '{:s}' does "
-               "not exist.".format(inputs.ptfile), pyrat.log)
-    pyrat.ptfile = os.path.realpath(inputs.ptfile)
-  # Jasmina ---
 
   # Check that input files exist:
   if inputs.atmfile is None:

--- a/pyratbay/pyrat/objects.py
+++ b/pyratbay/pyrat/objects.py
@@ -36,9 +36,6 @@ class Pyrat(object):
     self.phy      = Physics()         # System physical parameters
     self.ret      = Retrieval()       # Retrieval variables
     # Files:
-    # Jasmina ---
-    self.ptfile      = None  # Pressure and temperaure file 
-    # Jasmina ---
     self.atmfile     = None  # Atmopheric-model file
     self.linedb      = None  # Line-transition data file
     self.molfile     = None  # Molecular-properties file


### PR DESCRIPTION
changed the following file to add option to read
pressure and temperature from a file:
pyrat/argum.py
pyrat/objects.py
atmopshere/atmopshere.py
pbay/driver.py
pbay/argum.py

in the atm.cfg file only these two lines need to be added
no need to touch other stuff
# Read PTfile (pres units ba, temp units K)
ptfile = _path_

*****
Bumped Pyrat Bay to version 0.0.82.
Bumped Pyrat to version 1.2.57.
*****